### PR TITLE
Always use a string if the type is string

### DIFF
--- a/hsds_schema.py
+++ b/hsds_schema.py
@@ -396,10 +396,13 @@ def get_example(schemas, schema_name, simple):
             continue
         example = value.get("example")
         if example:
-            try:
-                results[key] = int(example)
-            except ValueError:
+            if value.get("type") == "string":
                 results[key] = example
+            else:
+                try:
+                    results[key] = int(example)
+                except ValueError:
+                    results[key] = example
         
         obj_ref = value.get('$ref')
 


### PR DESCRIPTION
Here's the example that's a problem https://github.com/openreferral/specification/blob/3.0-dev/schema/organization_identifier.json#L63
An alternative would be to replace the example with a value that can't be an integer.