### PR TITLE
Re-add shebang at start of hsds_schema.py

### DIFF
--- a/hsds_schema.py
+++ b/hsds_schema.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import csv
 import os
 import copy


### PR DESCRIPTION
@kindly this was removed as part of your windows compatibility work. Can we add it back in? I thought it would be fine, since it should just be seen as a comment. But, if it is a problem, I can just change how we call the script.